### PR TITLE
Present bed to printer front on stop print

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -998,7 +998,7 @@
 
   //#define MENU_ADDAUTOSTART               // Add a menu option to run auto#.g files
 
-  #define EVENT_GCODE_SD_STOP "G28XY"       // G-code to run on Stop Print (e.g., "G28XY" or "G27")
+  #define EVENT_GCODE_SD_ABORT "G28X\nG0 Y" STRINGIFY(Y_BED_SIZE) " F1500\nM84 X Y E"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
 
   /**
    * 


### PR DESCRIPTION
### Description

Modify the g-code in `EVENT_GCODE_SD_ABORT` to add a _G0_ command. This presents the bed forward.

### Benefits

Enables the user easy access to the print area.

### Related Issues

Closes #17.
