### PR TITLE
Add CI workflow to run tests for compiler errors

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -1,0 +1,123 @@
+#
+# test-builds.yml
+# Do test builds to catch compile errors
+#
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+    - bugfix-2.0.x
+    paths-ignore:
+    - config/**
+    - data/**
+    - docs/**
+    - '**/*.md'
+  push:
+    branches:
+    - bugfix-2.0.x
+    paths-ignore:
+    - config/**
+    - data/**
+    - docs/**
+    - '**/*.md'
+
+jobs:
+  test_builds:
+    name: Run All Tests
+    if: github.repository == 'JGMaker3dofficial/artistd'
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        test-platform:
+        # Base Environments
+
+        - DUE
+        - esp32
+        - linux_native
+        - mega2560
+        - teensy31
+        - teensy35
+        - teensy41
+        - SAMD51_grandcentral_m4
+
+        # Extended AVR Environments
+
+        - FYSETC_F6_13
+        - mega1280
+        - rambo
+        - sanguino1284p
+        - sanguino644p
+
+        # Extended STM32 Environments
+
+        - STM32F103RC_btt
+        - STM32F103RC_btt_USB
+        - STM32F103RE_btt
+        - STM32F103RE_btt_USB
+        - STM32F103RC_fysetc
+        - STM32F103RC_meeb
+        - jgaurora_a5s_a1
+        - STM32F103VE_longer
+        - STM32F407VE_black
+        - STM32F401VE_STEVAL
+        - BIGTREE_BTT002
+        - BIGTREE_SKR_PRO
+        - BIGTREE_GTR_V1_0
+        - mks_robin
+        - mks_robin_stm32
+        - ARMED
+        - FYSETC_S6
+        - STM32F070CB_malyan
+        - STM32F070RB_malyan
+        - malyan_M300
+        - mks_robin_lite
+        - FLYF407ZG
+        - rumba32
+        - mks_robin_pro
+        - STM32F103RET6_creality
+        - LERDGEX
+        - mks_robin_nano35
+
+        # Put lengthy tests last
+
+        - LPC1768
+        - LPC1769
+
+        # STM32 with non-STM framework. both broken for now. they should use HAL_STM32 which is working.
+
+        #- STM32F4
+        #- STM32F7
+
+        # Non-working environment tests
+        #- at90usb1286_cdc
+        #- at90usb1286_dfu
+        #- STM32F103CB_malyan
+        #- mks_robin_mini
+
+    steps:
+
+    - name: Select Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7' # Version range or exact version of a Python version to use, using semvers version range syntax.
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+    - name: Install PlatformIO
+      run: |
+        pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
+        platformio update
+
+    - name: Check out the PR
+      uses: actions/checkout@v2
+
+    - name: Run ${{ matrix.test-platform }} Tests
+      run: |
+        # Inline tests script
+        chmod +x buildroot/bin/*
+        chmod +x buildroot/tests/*
+        export PATH=./buildroot/bin/:./buildroot/tests/:${PATH}
+        run_tests . ${{ matrix.test-platform }}


### PR DESCRIPTION
### Requirements

Create an environment of quality through continuous integration builds.

### Description

This adds in the same CI flow that the Marlin firmware uses for testing commits and PRs.

### Benefits

Adds a safety check for the code that is committed. If it fails to build then it shouldn't be incorporated into the main branch.