### PR TITLE
Fix X2 min position

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -622,7 +622,7 @@
 #if ENABLED(DUAL_X_CARRIAGE)
   #define X1_MIN_POS X_MIN_POS     // Set to X_MIN_POS
   #define X1_MAX_POS X_BED_SIZE-5  // Set a maximum so the first X-carriage can't hit the parked second X-carriage
-  #define X2_MIN_POS    80         // Set a minimum to ensure the  second X-carriage can't hit the parked first X-carriage  CAD测量 62mm 
+  #define X2_MIN_POS     3         // Set a minimum to ensure the  second X-carriage can't hit the parked first X-carriage  CAD测量 62mm
   #define X2_MAX_POS   370 //371.4 //372.8 //435.3 //336       // Set this to the distance between toolheads when both heads are homed  手工测 284   增加上层向左偏移，减小向右  新机实测两喷头间距离为435mm
   #define X2_HOME_DIR    1         // Set to 1. The second X-carriage always homes to the maximum endstop position
   #define X2_HOME_POS X2_MAX_POS   // Default X2 home position. Set to X2_MAX_POS.


### PR DESCRIPTION
### Description

Change X2_MIN_POS to 3 so that the nozzle for the second extruder can get to the 0,0 X,Y position.

### Benefits

This fixes some issues regarding the second extruder not being able to get to the 0,0 position.

### Related Issues

Closes #47 
